### PR TITLE
Fix inconsistent DLL state after inserting existing node

### DIFF
--- a/contracts/DLL.sol
+++ b/contracts/DLL.sol
@@ -17,7 +17,7 @@ library DLL {
 		return getStart(self) == NULL_NODE_ID;
 	}
 
-	function exists(Data storage self, uint _curr) public view returns (bool) {
+	function contains(Data storage self, uint _curr) public view returns (bool) {
 		if (isEmpty(self) || _curr == NULL_NODE_ID) {
 			return false;
 		} 
@@ -52,7 +52,7 @@ library DLL {
 	*/
 	function insert(Data storage self, uint _prev, uint _curr, uint _next) public {
 		require(_curr != NULL_NODE_ID);
-		require(_prev == NULL_NODE_ID || exists(self, _prev));
+		require(_prev == NULL_NODE_ID || contains(self, _prev));
 		require(getNext(self, _prev) == _next);
 
 		remove(self, _curr);
@@ -65,7 +65,7 @@ library DLL {
 	}
 
 	function remove(Data storage self, uint _curr) public {
-		if (!exists(self, _curr)) {
+		if (!contains(self, _curr)) {
 			return;
 		}
 

--- a/contracts/DLL.sol
+++ b/contracts/DLL.sol
@@ -1,6 +1,9 @@
 pragma solidity^0.4.11;
 
 library DLL {
+
+	uint constant NULL_NODE_ID = 0;
+
 	struct Node {
 		uint next;
 		uint prev;
@@ -8,6 +11,20 @@ library DLL {
 
 	struct Data {
 		mapping(uint => Node) dll;
+	}
+
+	function isEmpty(Data storage self) public view returns (bool) {
+		return getStart(self) == NULL_NODE_ID;
+	}
+
+	function exists(Data storage self, uint _curr) public view returns (bool) {
+		if (isEmpty(self) || _curr == NULL_NODE_ID) {
+			return false;
+		} 
+
+		bool isSingleNode = (getStart(self) == _curr) && (getEnd(self) == _curr);
+		bool isNullNode = (getNext(self, _curr) == NULL_NODE_ID) && (getPrev(self, _curr) == NULL_NODE_ID);
+		return isSingleNode || !isNullNode;
 	}
 
 	function getNext(Data storage self, uint _curr) public view returns (uint) {
@@ -18,7 +35,28 @@ library DLL {
 		return self.dll[_curr].prev;
 	}
 
+	function getStart(Data storage self) public view returns (uint) {
+		return getNext(self, NULL_NODE_ID);
+	}
+
+	function getEnd(Data storage self) public view returns (uint) {
+		return getPrev(self, NULL_NODE_ID);
+	}
+
+	/**
+	@dev Inserts a new node between _prev and _next. When inserting a node already existing in 
+	the list it will be automatically removed from the old position.
+	@param _prev the node which _new will be inserted after
+	@param _curr the id of the new node being inserted
+	@param _next the node which _new will be inserted before
+	*/
 	function insert(Data storage self, uint _prev, uint _curr, uint _next) public {
+		require(_curr != NULL_NODE_ID);
+		require(_prev == NULL_NODE_ID || exists(self, _prev));
+		require(getNext(self, _prev) == _next);
+
+		remove(self, _curr);
+
 		self.dll[_curr].prev = _prev;
 		self.dll[_curr].next = _next;
 
@@ -27,13 +65,16 @@ library DLL {
 	}
 
 	function remove(Data storage self, uint _curr) public {
+		if (!exists(self, _curr)) {
+			return;
+		}
+
 		uint next = getNext(self, _curr);
 		uint prev = getPrev(self, _curr);
 
 		self.dll[next].prev = prev;
 		self.dll[prev].next = next;
 
-		self.dll[_curr].next = _curr;
-		self.dll[_curr].prev = _curr;
+		delete self.dll[_curr];
 	}
 }

--- a/contracts/TestDLL.sol
+++ b/contracts/TestDLL.sol
@@ -1,0 +1,41 @@
+pragma solidity^0.4.0;
+
+import "./DLL.sol";
+
+contract TestDLL {
+
+	using DLL for DLL.Data;
+	DLL.Data dll;
+
+	function isEmpty() public view returns (bool) {
+		return dll.isEmpty();
+	}
+	
+	function exists(uint _curr) public view returns (bool) {
+		return dll.exists(_curr);
+	}
+
+	function getNext(uint _curr) public view returns (uint) {
+		return dll.getNext(_curr);
+	}
+	
+	function getPrev(uint _curr) public view returns (uint) {
+		return dll.getPrev(_curr);
+	}
+	
+	function getStart() public view returns (uint) {
+		return dll.getStart();
+	}
+	
+	function getEnd() public view returns (uint) {
+		return dll.getEnd();
+	}
+
+	function insert(uint _prev, uint _curr, uint _next) public {
+		dll.insert(_prev, _curr, _next);
+	}
+
+	function remove(uint _curr) public {
+		dll.remove(_curr);
+	}
+}

--- a/contracts/TestDLL.sol
+++ b/contracts/TestDLL.sol
@@ -11,8 +11,8 @@ contract TestDLL {
 		return dll.isEmpty();
 	}
 	
-	function exists(uint _curr) public view returns (bool) {
-		return dll.exists(_curr);
+	function contains(uint _curr) public view returns (bool) {
+		return dll.contains(_curr);
 	}
 
 	function getNext(uint _curr) public view returns (uint) {

--- a/migrations/3_optional_for_test.js
+++ b/migrations/3_optional_for_test.js
@@ -1,0 +1,12 @@
+/* global artifacts */
+
+const DLL = artifacts.require('./DLL.sol');
+const TestDLL = artifacts.require('TestDLL.sol');
+
+module.exports = function (deployer, network) {
+  if (network === 'develop' || network === 'test') {
+    deployer.link(DLL, TestDLL);
+
+    deployer.deploy(TestDLL);
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sol-dll",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sol-dll",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Doubly-linked list in Solidity",
   "scripts": {
     "test": "eslint ./ && truffle test",

--- a/test/contains.js
+++ b/test/contains.js
@@ -3,14 +3,14 @@
 const TestDLL = artifacts.require('TestDLL.sol');
 
 contract('DLL', () => {
-  describe('Function: exists', () => {
+  describe('Function: contains', () => {
     it('Should return false for 0 node', async () => {
       const proxy = await TestDLL.deployed();
 
       await proxy.insert(0, 1, 0);
-      const exists = await proxy.exists(0);
+      const contains = await proxy.contains(0);
 
-      assert.strictEqual(exists, false, 'expected exists to be false');
+      assert.strictEqual(contains, false, 'expected contains to be false');
     });
   });
 });

--- a/test/exists.js
+++ b/test/exists.js
@@ -1,0 +1,17 @@
+/* global artifacts contract describe assert it */
+
+const TestDLL = artifacts.require('TestDLL.sol');
+
+contract('DLL', () => {
+  describe('Function: exists', () => {
+    it('Should return false for 0 node', async () => {
+      const proxy = await TestDLL.deployed();
+
+      await proxy.insert(0, 1, 0);
+      const exists = await proxy.exists(0);
+
+      assert.strictEqual(exists, false, 'expected exists to be false');
+    });
+  });
+});
+

--- a/test/insert.js
+++ b/test/insert.js
@@ -1,0 +1,55 @@
+/* global artifacts contract describe assert it */
+
+const TestDLL = artifacts.require('TestDLL.sol');
+const utils = require('./utils.js');
+
+contract('DLL', () => {
+  describe('Function: insert', () => {
+    it('Should not allow inserting 0 node', async () => {
+      const proxy = await TestDLL.deployed();
+
+      try {
+        await proxy.insert(0, 0, 0);
+        assert(false, 'Inserted 0 node');
+      } catch (err) {
+        assert(utils.isEVMException(err), err.toString());
+      }
+    });
+
+    it('Should not allow inserting a node with invalid next node', async () => {
+      const proxy = await TestDLL.deployed();
+
+      try {
+        await proxy.insert(0, 0, 1);
+        assert(false, 'Inserted a node with invalid next node');
+      } catch (err) {
+        assert(utils.isEVMException(err), err.toString());
+      }
+    });
+
+    it('Should not allow inserting a node with non-existent prev node', async () => {
+      const proxy = await TestDLL.deployed();
+
+      try {
+        await proxy.insert(5, 6, 0);
+        assert(false, 'Inserted a node with non-existent prev node');
+      } catch (err) {
+        assert(utils.isEVMException(err), err.toString());
+      }
+    });
+
+    it('Should change the position when inserting an existing node', async () => {
+      const proxy = await TestDLL.deployed();
+
+      await proxy.insert(0, 1, 0);
+      await proxy.insert(1, 2, 0);
+      await proxy.insert(2, 1, 0);
+
+      const start = await proxy.getStart();
+      const end = await proxy.getEnd();
+      assert.strictEqual(start.toString(10), '2', 'expected start to be 2');
+      assert.strictEqual(end.toString(10), '1', 'expected end to be 1');
+    });
+  });
+});
+

--- a/test/remove.js
+++ b/test/remove.js
@@ -1,0 +1,20 @@
+/* global artifacts contract describe assert it */
+
+const TestDLL = artifacts.require('TestDLL.sol');
+
+contract('DLL', () => {
+  describe('Function: remove', () => {
+    it('Should ignore removing non-existent node', async () => {
+      const proxy = await TestDLL.deployed();
+
+      await proxy.insert(0, 1, 0);
+      await proxy.remove(2);
+
+      const start = await proxy.getStart();
+      const end = await proxy.getEnd();
+      assert.strictEqual(start.toString(10), '1', 'expected start to be 1');
+      assert.strictEqual(end.toString(10), '1', 'expected end to be 1');
+    });
+  });
+});
+

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,15 @@
+/* eslint-env mocha */
+
+const utils = {
+  isEVMException: err => (
+    utils.isInvalidOpcode(err) || utils.isRevert(err)
+  ),
+  isInvalidOpcode: err => (
+    err.toString().includes('invalid opcode')
+  ),
+  isRevert: err => (
+    err.toString().includes('revert')
+  ),
+};
+
+module.exports = utils;


### PR DESCRIPTION
Fix for this issue https://github.com/skmgoldin/tcr/issues/1

As part of this fix a few other issue have been fixed:
 - Inconsistent DLL state after inserting 0 node
 - Inconsistent DLL state after inserting a node passing invalid next node
 - Inconsistent DLL state after inserting a node passing non-existent prev node
 - Inconsistent DLL state after removing non-existent node

Added test cases for the above issues.

When removing a node I used `delete` keyword (equivalent to setting prev and next to 0) instead of linking the node to itself. This should make the remove operation cheaper due to gas refund http://yellowpaper.io.